### PR TITLE
Update to mirror site

### DIFF
--- a/Rpackage/dev/GdeltTools/R/DownloadGdelt.R
+++ b/Rpackage/dev/GdeltTools/R/DownloadGdelt.R
@@ -1,8 +1,8 @@
 DownloadGdelt <- function(f,
                           local.folder,
                           max.local.mb,
-                          historical.url.root="http://gdelt.utdallas.edu/data/backfiles/",
-                          daily.url.root="http://gdelt.utdallas.edu/data/dailyupdates/",
+                          historical.url.root="http://gdelt.umn.edu/data/backfiles/",
+                          daily.url.root="http://gdelt.umn.edu/data/dailyupdates/",
                           verbose=TRUE) {
   # Dowloads a single file, then removes files if necessary to get under max.local.mb
   # Returns TRUE if file downloaded successfully, FALSE otherwise


### PR DESCRIPTION
University of Minnesota has a new mirror of the GDELT website. The use of the mirror in the automated scripts will move some of the pressure from the UT-Dallas site to the mirror. The UMN site also has faster download speeds than the UT-Dallas site.
